### PR TITLE
Solve error in setup:di:compile

### DIFF
--- a/Gauge/GoogleAnalytics/Block/Success.php
+++ b/Gauge/GoogleAnalytics/Block/Success.php
@@ -8,7 +8,6 @@ class Success extends \Magento\Framework\View\Element\Template
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Checkout\Model\Session $session
      * @param \Magento\Sales\Model\Order $order
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Gauge\GoogleAnalytics\Helper\Data $helper
      * @param array $data
      */
@@ -17,14 +16,12 @@ class Success extends \Magento\Framework\View\Element\Template
         \Magento\Framework\View\Element\Template\Context $context,
         \Magento\Checkout\Model\Session $session,
         \Magento\Sales\Model\Order $order,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Gauge\GoogleAnalytics\Helper\Data $helper,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->session = $session;
         $this->order = $order;
-        $this->storeManager = $storeManager;
         $this->helper = $helper;
     }
 
@@ -46,8 +43,8 @@ class Success extends \Magento\Framework\View\Element\Template
     * @return string
     */
     public function getStoreName() {
-        return $this->storeManager->getStore()->getName();
-    }        
+        return $this->_storeManager->getStore()->getName();
+    }
 
     /**
     * @return string


### PR DESCRIPTION
When triggering setup:di:compile, you'll get the following error:

```
Incorrect dependency in class Gauge\GoogleAnalytics\Block\Success in app/code/Gauge/GoogleAnalytics/Block/Success.php
\Magento\Store\Model\StoreManagerInterface already exists in context object
Total Errors Count: 1
```

I've solved this by removing `\Magento\Store\Model\StoreManagerInterface` from the constructor, and using the parent  `_storeManager` instead.